### PR TITLE
Update datasets_advanced.ipynb

### DIFF
--- a/tutorials/datasets_advanced.ipynb
+++ b/tutorials/datasets_advanced.ipynb
@@ -213,7 +213,7 @@
     }
    ],
    "source": [
-    "print(b.filter(qualifier'ld_func@lc01', check_default=False))"
+    "print(b.filter(qualifier='ld_func@lc01', check_default=False))"
    ]
   },
   {


### PR DESCRIPTION
fixed a simple typo, missing '=' sign
around input line 8 was
print(b.filter(qualifier'ld_func@lc01', check_default=False)) changed to
print(b.filter(qualifier='ld_func@lc01', check_default=False))